### PR TITLE
Playwright C#: local/Sauce Labs native WebSocket target switch with class-grouped sessions

### DIFF
--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -18,6 +18,8 @@ on:
 env:
   SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
   SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+  TARGET: sauce
+  GROUPING: class
 
 jobs:
   playwright-tests:
@@ -37,20 +39,24 @@ jobs:
     
     - name: Build
       run: dotnet build PlaywrightExamples/PlaywrightExamples.csproj --no-restore --configuration Release
-    
-    - name: Install Playwright browsers
-      run: pwsh PlaywrightExamples/bin/Release/net8.0/playwright.ps1 install --with-deps
-    
+
     - name: Run tests
       uses: nick-fields/retry@v4
       with:
         max_attempts: 3
         timeout_minutes: 30
-        command: dotnet test PlaywrightExamples/PlaywrightExamples.csproj --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=playwright-examples-results.trx"
-    
+        command: dotnet test PlaywrightExamples/PlaywrightExamples.csproj --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=playwright-examples-results.trx" --logger "html;LogFileName=playwright-examples-report.html"
+
     - name: Upload test results
       uses: actions/upload-artifact@v7
       if: always()
       with:
         name: playwright-examples-results
         path: '**/playwright-examples-results.trx'
+
+    - name: Upload HTML report
+      uses: actions/upload-artifact@v7
+      if: always()
+      with:
+        name: playwright-examples-html-report
+        path: '**/playwright-examples-report.html'

--- a/.github/workflows/playwright-examples.yml
+++ b/.github/workflows/playwright-examples.yml
@@ -25,7 +25,11 @@ jobs:
   playwright-tests:
     name: Playwright NUnit Examples
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+
     steps:
     - uses: actions/checkout@v7
     
@@ -46,6 +50,14 @@ jobs:
         max_attempts: 3
         timeout_minutes: 30
         command: dotnet test PlaywrightExamples/PlaywrightExamples.csproj --no-build --configuration Release --verbosity normal --logger "trx;LogFileName=playwright-examples-results.trx" --logger "html;LogFileName=playwright-examples-report.html"
+
+    - name: Publish test report to job summary and checks
+      uses: dorny/test-reporter@v3
+      if: always()
+      with:
+        name: Playwright Examples Test Report
+        path: '**/playwright-examples-results.trx'
+        reporter: dotnet-trx
 
     - name: Upload test results
       uses: actions/upload-artifact@v7

--- a/PlaywrightExamples/README.md
+++ b/PlaywrightExamples/README.md
@@ -1,26 +1,48 @@
 # Playwright Examples
 
-This project contains Playwright test examples for the [Sauce Demo](https://www.saucedemo.com/) 
-website using C# and NUnit, designed to run on **Sauce Labs** using the Connect over CDP feature.
+This project contains Playwright test examples for the [Sauce Demo](https://www.saucedemo.com/)
+website using C# and NUnit. Tests run either against a **locally launched browser** (the default)
+or on **Sauce Labs** via its native Playwright WebSocket endpoint - switching between them is a
+single environment variable, and everything else about the test (context/page isolation, session
+pooling, browser engine selection) behaves identically either way.
 
 ## Overview
 
-These tests leverage Playwright's CDP (Chrome DevTools Protocol) connection to run tests on 
-Sauce Labs' cloud infrastructure. This approach:
-- Creates a WebDriver session on Sauce Labs
-- Retrieves the CDP endpoint from the session
-- Connects Playwright to the remote browser via `ConnectOverCDPAsync`
-- Reports test results back to Sauce Labs
+`TARGET` picks where the browser lives:
+- `TARGET` unset or `local` (default): launches a browser on the machine running the tests, via
+  `IBrowserType.LaunchAsync`. No Sauce Labs account needed.
+- `TARGET=sauce`: connects to Sauce Labs' native Playwright WebSocket endpoint instead - creates a
+  native Playwright session on Sauce Labs, connects via `ConnectAsync` to the returned WebSocket
+  endpoint, and reports test results back to Sauce Labs.
+
+`BROWSER` picks the engine (`chromium`, `firefox` or `webkit`, default `chromium`) - it means the
+same thing for both targets, so `BROWSER=firefox` runs Firefox whether you're local or on Sauce.
+
+`GROUPING` picks how sessions are shared across tests:
+- `GROUPING` unset or `class` (default): one session per test class/fixture, named after the class.
+  Every test class is `[Parallelizable(ParallelScope.Fixtures)]`, so different classes run in
+  parallel with each other, but tests *within* one class run sequentially - meaning exactly one
+  test at a time ever uses a given class's session.
+- `GROUPING=test`: one dedicated, never-shared session per test, named after the test itself.
+
+### Session lifecycle
+
+A session (local browser or Sauce Labs job) is checked out for a test and, on teardown, either kept
+alive for reuse (test passed) or closed immediately (test failed) - so a failing test never leaves
+a possibly-dirty browser behind for whatever test picks up that session next. Each test still gets
+its own fresh, isolated `BrowserContext`/`Page` regardless of session reuse. Whatever sessions are
+still open once the whole run finishes are closed out by `SauceSessionsTeardown` in `TestBase.cs`.
+This applies the same way regardless of `TARGET` or `GROUPING`.
 
 ## Prerequisites
 
 - .NET 8.0 SDK
-- Sauce Labs account with valid credentials
-- `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY` environment variables set
+- For `TARGET=sauce`: a Sauce Labs account, with `SAUCE_USERNAME` and `SAUCE_ACCESS_KEY`
+  environment variables set
 
 ## Setup
 
-1. Set your Sauce Labs credentials:
+1. If running against Sauce Labs, set your credentials:
    ```bash
    export SAUCE_USERNAME="your-username"
    export SAUCE_ACCESS_KEY="your-access-key"
@@ -38,9 +60,24 @@ Sauce Labs' cloud infrastructure. This approach:
 
 ## Running Tests
 
-Run all tests:
+Run all tests locally (default):
 ```bash
 dotnet test
+```
+
+Run all tests on Sauce Labs:
+```bash
+TARGET=sauce dotnet test
+```
+
+Run locally with a specific browser engine:
+```bash
+BROWSER=firefox dotnet test
+```
+
+Run with one session per test instead of one per class:
+```bash
+GROUPING=test dotnet test
 ```
 
 Run tests with detailed output:
@@ -58,10 +95,18 @@ Run a single test:
 dotnet test --filter "Name=SignInSuccessful"
 ```
 
+Run with an HTML report (built into the .NET test platform, no extra package needed):
+```bash
+dotnet test --logger "html;LogFileName=report.html"
+```
+This writes `TestResults/report.html` with a pass/fail/duration table for the run. It works the
+same way regardless of `TARGET`.
+
 ## Viewing Test Results
 
-After tests complete, you can view the results in the [Sauce Labs Dashboard](https://app.saucelabs.com/). 
-The console output will include direct links to each test job:
+When `TARGET=sauce`, you can view the results in the [Sauce Labs Dashboard](https://app.saucelabs.com/).
+The console output will include direct links to each test job (not printed for local runs, since
+there's no Sauce job to link to):
 
 ```
 SauceOnDemandSessionID=<session-id> job-name=<test-name>
@@ -82,7 +127,7 @@ Test Job Link: https://app.saucelabs.com/tests/<session-id>
 PlaywrightExamples/
 ├── PlaywrightExamples.csproj
 ├── README.md
-├── TestBase.cs          # Sauce Labs CDP connection setup
+├── TestBase.cs          # Local/Sauce Labs session setup (class-grouped or per-test)
 └── Tests/
     ├── AuthenticationTests.cs
     ├── CartTests.cs
@@ -93,18 +138,25 @@ PlaywrightExamples/
 
 ## Configuration
 
-The Sauce Labs configuration is defined in `TestBase.cs`:
+Configuration is defined in `TestBase.cs` and controlled via environment variables:
 
-| Setting | Default Value |
-|---------|---------------|
-| Data Center | US West (`ondemand.us-west-1.saucelabs.com`) |
-| Platform | macOS 13 |
-| Browser | Chrome |
+| Variable | Default | Description |
+|----------|---------|--------------|
+| `TARGET` | `local` | Where the browser runs: `local` or `sauce` |
+| `BROWSER` | `chromium` | Browser engine: `chromium`, `firefox`, `webkit` - same meaning for both targets |
+| `GROUPING` | `class` | Session sharing: `class` (one session per test class) or `test` (one per test) |
+| `SAUCE_REGION` | `us-west-1` | Data center for all Sauce Labs URLs (e.g. `us-east-1`, `eu-central-1`). Only used when `TARGET=sauce` |
 
-### Adding Annotations
-
-You can add annotations to your tests that will appear in the Sauce Labs command log:
-
-```csharp
-await AnnotateAsync("Starting checkout process");
+Examples:
+```bash
+BROWSER=firefox dotnet test
+GROUPING=test TARGET=sauce BROWSER=webkit SAUCE_REGION=eu-central-1 dotnet test
 ```
+
+Note: `GROUPING` only controls how `TestBase.cs` shares Sauce/local sessions across tests - it
+can't change how many tests NUnit actually runs concurrently, since that's governed by each test
+class's `[Parallelizable]` attribute, a compile-time setting. Test classes are currently
+`ParallelScope.Fixtures` (classes run in parallel with each other, tests within one class run
+sequentially), which is what makes `GROUPING=class` safe - if the intra-class concurrency needs to
+change, that's a separate edit to `Tests/*.cs`, not something `GROUPING` can flip at runtime. To
+control the number of concurrent NUnit workers directly, use `dotnet test -- NUnit.NumberOfTestWorkers=N`.

--- a/PlaywrightExamples/README.md
+++ b/PlaywrightExamples/README.md
@@ -31,7 +31,7 @@ A session (local browser or Sauce Labs job) is checked out for a test and, on te
 alive for reuse (test passed) or closed immediately (test failed) - so a failing test never leaves
 a possibly-dirty browser behind for whatever test picks up that session next. Each test still gets
 its own fresh, isolated `BrowserContext`/`Page` regardless of session reuse. Whatever sessions are
-still open once the whole run finishes are closed out by `SauceSessionsTeardown` in `TestBase.cs`.
+still open once the whole run finishes are closed out by `SessionsTeardown` in `TestBase.cs`.
 This applies the same way regardless of `TARGET` or `GROUPING`.
 
 ## Prerequisites

--- a/PlaywrightExamples/TestBase.cs
+++ b/PlaywrightExamples/TestBase.cs
@@ -1,5 +1,8 @@
+using System.Collections.Concurrent;
+using System.Reflection;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 using Microsoft.Playwright;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
@@ -12,90 +15,152 @@ public static class BuildInfo
     public static readonly string Identifier = $"{Name}: {DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
 }
 
+// A session (local browser or Sauce Labs job) is checked out per test and, on teardown, either
+// kept alive for reuse (test passed) or closed immediately (test failed) so nobody ever inherits a
+// possibly-dirty browser. GROUPING decides how sessions are shared:
+// - "class" (default): one session per test class/fixture, named after the class. Relies on the
+//   test classes being [Parallelizable(ParallelScope.Fixtures)] - fixtures run in parallel with
+//   each other, but tests *within* one fixture run sequentially, so exactly one test at a time
+//   ever touches a given class's session (no locking needed, and a mid-class failure can safely
+//   close the shared browser without yanking it out from under a concurrently running sibling).
+// - "test": one dedicated, never-shared session per test, named after the test itself.
+// TARGET selects whether that session is a locally launched browser or a Sauce Labs one - BROWSER
+// (chromium/firefox/webkit) means the same thing either way, so switching targets is a one-line change.
 [TestFixture]
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 public abstract class TestBase
 {
+    private enum Target
+    {
+        Local,
+        Sauce
+    }
+
+    private enum SessionGrouping
+    {
+        Class,
+        Test
+    }
+
+    private static readonly Target RunTarget =
+        string.Equals(Environment.GetEnvironmentVariable("TARGET"), "sauce", StringComparison.OrdinalIgnoreCase)
+            ? Target.Sauce
+            : Target.Local;
+
+    private static readonly SessionGrouping Grouping =
+        string.Equals(Environment.GetEnvironmentVariable("GROUPING"), "test", StringComparison.OrdinalIgnoreCase)
+            ? SessionGrouping.Test
+            : SessionGrouping.Class;
+
+    private static readonly string BrowserName = Environment.GetEnvironmentVariable("BROWSER") ?? "chromium";
+
     private static readonly string SauceUsername = Environment.GetEnvironmentVariable("SAUCE_USERNAME") ?? "";
     private static readonly string SauceAccessKey = Environment.GetEnvironmentVariable("SAUCE_ACCESS_KEY") ?? "";
-    private static readonly string SauceUrl = "https://ondemand.us-west-1.saucelabs.com/wd/hub/";
-    
-    protected IPlaywright Playwright { get; private set; } = null!;
-    protected IBrowser Browser { get; private set; } = null!;
+    private static readonly string SauceRegion = Environment.GetEnvironmentVariable("SAUCE_REGION") ?? "us-west-1";
+    private static readonly string SauceUrl = $"https://ondemand.{SauceRegion}.saucelabs.com";
+    private static readonly string SauceApiUrl = $"https://api.{SauceRegion}.saucelabs.com";
+
+    // The native session endpoint only accepts a major.minor version (e.g. "1.58"), not the full package version.
+    private static readonly string PlaywrightVersion = GetPlaywrightVersion();
+
+    // "class" mode only: one entry per test class, holding that class's shared session. Lazy<Task<>>
+    // means only one caller ever actually opens the session even if this assumption is ever violated.
+    private static readonly ConcurrentDictionary<string, Lazy<Task<WorkerSession>>> ClassSessions = new();
+
     protected IPage Page { get; private set; } = null!;
-    
-    private string? _sessionId;
-    private IAPIRequestContext? _requestContext;
+
+    private WorkerSession _session = null!;
+    private IBrowserContext? _context;
 
     [SetUp]
     public async Task BaseSetUp()
     {
-        string testName = $"{TestContext.CurrentContext.Test.ClassName}: {TestContext.CurrentContext.Test.Name}";
-        
-        Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
-        
-        // Create API request context for Sauce Labs
-        _requestContext = await Playwright.APIRequest.NewContextAsync(new APIRequestNewContextOptions
+        if (Grouping == SessionGrouping.Class)
         {
-            BaseURL = SauceUrl
-        });
-        
-        // Build capabilities payload
-        var payload = BuildCapabilitiesPayload(testName);
-        
-        // Create session on Sauce Labs
-        var response = await _requestContext.PostAsync("session", new APIRequestContextOptions
-        {
-            DataObject = payload,
-            Timeout = 120000
-        });
-        
-        var responseText = await response.TextAsync();
-        using var jsonDoc = JsonDocument.Parse(responseText);
-        var value = jsonDoc.RootElement.GetProperty("value");
-        
-        _sessionId = value.GetProperty("sessionId").GetString();
-        var cdpEndpoint = value.GetProperty("capabilities").GetProperty("se:cdp").GetString();
-        
-        // Connect to browser via CDP
-        Browser = await Playwright.Chromium.ConnectOverCDPAsync(cdpEndpoint!);
-        
-        // Get the default context and page, or create new ones
-        var contexts = Browser.Contexts;
-        if (contexts.Count > 0)
-        {
-            var pages = contexts[0].Pages;
-            Page = pages.Count > 0 ? pages[0] : await contexts[0].NewPageAsync();
+            var className = TestContext.CurrentContext.Test.ClassName ?? "";
+            var lazySession = ClassSessions.GetOrAdd(className, _ =>
+                new Lazy<Task<WorkerSession>>(() => OpenSessionAsync(ShortClassName(className)),
+                    LazyThreadSafetyMode.ExecutionAndPublication));
+            _session = await lazySession.Value;
         }
         else
         {
-            var context = await Browser.NewContextAsync(new BrowserNewContextOptions
-            {
-                ViewportSize = ViewportSize.NoViewport
-            });
-            Page = await context.NewPageAsync();
+            _session = await OpenSessionAsync(TestContext.CurrentContext.Test.Name);
         }
+
+        _context = await _session.Browser.NewContextAsync();
+        Page = await _context.NewPageAsync();
+    }
+
+    private static string ShortClassName(string fullClassName) => fullClassName.Split('.')[^1];
+
+    private static async Task<WorkerSession> OpenSessionAsync(string sessionName)
+    {
+        var playwright = await Playwright.CreateAsync();
+        var browserType = GetBrowserType(playwright, BrowserName);
+
+        if (RunTarget == Target.Local)
+        {
+            var browser = await browserType.LaunchAsync();
+            return new WorkerSession(playwright, browser);
+        }
+
+        var requestContext = await playwright.APIRequest.NewContextAsync(new APIRequestNewContextOptions
+        {
+            BaseURL = SauceUrl,
+            HttpCredentials = new HttpCredentials
+            {
+                Username = SauceUsername,
+                Password = SauceAccessKey,
+                Send = HttpCredentialsSend.Always
+            }
+        });
+
+        var payload = BuildCapabilitiesPayload(sessionName, BrowserName);
+
+        // The endpoint 303-redirects while the VM spins up; follow until we get a 200.
+        var response = await requestContext.PostAsync("playwright/session", new APIRequestContextOptions
+        {
+            DataObject = payload,
+            MaxRedirects = 0,
+            Timeout = 120000
+        });
+
+        while (response.Status == 303)
+        {
+            var location = response.Headers["location"];
+            response = await requestContext.GetAsync(location, new APIRequestContextOptions { MaxRedirects = 0 });
+        }
+
+        var responseText = await response.TextAsync();
+        using var jsonDoc = JsonDocument.Parse(responseText);
+        var root = jsonDoc.RootElement;
+        var value = root.TryGetProperty("value", out var v) ? v : root;
+
+        var sessionId = value.GetProperty("sessionId").GetString()!;
+        var wsEndpoint = value.GetProperty("wsEndpoint").GetString();
+
+        var sauceBrowser = await browserType.ConnectAsync($"{wsEndpoint}?browser={BrowserName}");
+
+        return new WorkerSession(playwright, sauceBrowser, sessionId, requestContext);
     }
 
     [TearDown]
     public async Task BaseTearDown()
     {
+        bool passed = false;
         try
         {
             string testName = TestContext.CurrentContext.Test.Name;
-            bool passed = TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed;
+            passed = TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed;
             string result = passed ? "passed" : "failed";
 
             Console.WriteLine($"Test: {testName} - Result: {result}");
-            
-            // Update test result on Sauce Labs
-            if (_requestContext != null && !string.IsNullOrEmpty(_sessionId))
+
+            if (_session.SessionId != null)
             {
-                await UpdateSauceResultAsync(passed);
+                PrintSauceJobLink(testName, _session.SessionId);
             }
-            
-            // Print Sauce Labs job link
-            PrintSauceJobLink(testName);
         }
         catch (Exception e)
         {
@@ -103,92 +168,120 @@ public abstract class TestBase
         }
         finally
         {
-            if (Page != null) await Page.CloseAsync();
-            if (Browser != null) await Browser.CloseAsync();
-            
-            // Delete session on Sauce Labs
-            if (_requestContext != null && !string.IsNullOrEmpty(_sessionId))
+            await Page.CloseAsync();
+            if (_context != null) await _context.CloseAsync();
+
+            if (Grouping == SessionGrouping.Class)
             {
-                await _requestContext.DeleteAsync($"session/{_sessionId}");
-                await _requestContext.DisposeAsync();
-            }
-            
-            Playwright?.Dispose();
-        }
-    }
-    
-    private Dictionary<string, object> BuildCapabilitiesPayload(string testName)
-    {
-        var sauceOptions = new Dictionary<string, object>
-        {
-            ["username"] = SauceUsername,
-            ["accessKey"] = SauceAccessKey,
-            ["devTools"] = true,
-            ["name"] = testName,
-            ["build"] = BuildInfo.Identifier
-        };
-        
-        var sessionRequest = new Dictionary<string, object>
-        {
-            ["platformName"] = "macOS 13",
-            ["browserName"] = "Chrome",
-            ["sauce:options"] = sauceOptions,
-            ["goog:chromeOptions"] = new Dictionary<string, object>
-            {
-                ["args"] = new[] { "--disable-features=SafeBrowsing,PasswordLeakToggleMove" },
-                ["prefs"] = new Dictionary<string, object>
+                // Passed: leave the session in ClassSessions for the next test in this class to
+                // reuse. Failed: evict and close it now instead of leaving a possibly-dirty
+                // browser for the next test in this class to inherit - safe to do unconditionally
+                // because ParallelScope.Fixtures guarantees no sibling test is using it right now.
+                if (!passed)
                 {
-                    ["credentials_enable_service"] = false,
-                    ["profile.password_manager_enabled"] = false,
-                    ["profile.password_manager_leak_detection"] = false
+                    var className = TestContext.CurrentContext.Test.ClassName ?? "";
+                    ClassSessions.TryRemove(className, out _);
+                    await CloseSessionAsync(_session, passed: false);
                 }
             }
-        };
-        
-        var capabilities = new Dictionary<string, object>
+            else
+            {
+                // "test" mode sessions are never shared, so there's nobody to hand this off to -
+                // always close and report, pass or fail.
+                await CloseSessionAsync(_session, passed);
+            }
+        }
+    }
+
+    private static async Task CloseSessionAsync(WorkerSession session, bool passed)
+    {
+        try
         {
-            ["alwaysMatch"] = sessionRequest
-        };
-        
+            if (session.SessionId != null && session.RequestContext != null)
+            {
+                await UpdateSauceResultAsync(session.RequestContext, session.SessionId, passed);
+            }
+
+            // The Sauce session ends when its WebSocket connection drops; a local browser just closes.
+            await session.Browser.CloseAsync();
+
+            if (session.RequestContext != null)
+            {
+                await session.RequestContext.DisposeAsync();
+            }
+
+            session.Playwright.Dispose();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Error closing session {session.SessionId}: {e.Message}");
+        }
+    }
+
+    // Closes every session still in ClassSessions ("test" mode never populates it - each session
+    // is already closed in BaseTearDown). Invoked once after all tests finish, by
+    // SauceSessionsTeardown's [OneTimeTearDown] below. Any class session that ever failed a test
+    // was already evicted and closed in BaseTearDown, so everything left here only ever ran
+    // passing tests - each is reported as passed.
+    internal static async Task CloseAllWorkerSessionsAsync()
+    {
+        foreach (var (_, lazySession) in ClassSessions)
+        {
+            await CloseSessionAsync(await lazySession.Value, passed: true);
+        }
+        ClassSessions.Clear();
+    }
+
+    private static Dictionary<string, object> BuildCapabilitiesPayload(string sessionName, string browserName)
+    {
         return new Dictionary<string, object>
         {
-            ["capabilities"] = capabilities
+            ["browserName"] = browserName,
+            ["platformName"] = "Linux",
+            ["playwrightVersion"] = PlaywrightVersion,
+            ["sauce:options"] = new Dictionary<string, object>
+            {
+                ["name"] = sessionName,
+                ["build"] = BuildInfo.Identifier
+            }
         };
     }
-    
-    private async Task UpdateSauceResultAsync(bool passed)
+
+    // The session endpoint accepts 'chromium', 'firefox' or 'webkit' - the same names Playwright
+    // itself uses, so no translation table is needed.
+    private static IBrowserType GetBrowserType(IPlaywright playwright, string browserName) => browserName.ToLowerInvariant() switch
     {
-        using var httpClient = new HttpClient();
-        var authString = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{SauceUsername}:{SauceAccessKey}"));
-        httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", authString);
-        
-        var updatePayload = new { passed };
-        var content = new StringContent(JsonSerializer.Serialize(updatePayload), Encoding.UTF8, "application/json");
-        
-        await httpClient.PutAsync($"https://api.us-west-1.saucelabs.com/rest/v1/{SauceUsername}/jobs/{_sessionId}", content);
+        "chromium" => playwright.Chromium,
+        "firefox" => playwright.Firefox,
+        "webkit" => playwright.Webkit,
+        _ => throw new ArgumentException(
+            $"Unsupported BROWSER \"{browserName}\". Use one of: chromium, firefox, webkit.")
+    };
+
+    private static string GetPlaywrightVersion()
+    {
+        // AssemblyInformationalVersion on Microsoft.Playwright.dll is a stale "1.0.0+<hash>",
+        // not the package version - AssemblyName.Version tracks the real one (e.g. 1.61.0.0).
+        var version = typeof(IPage).Assembly.GetName().Version;
+        return version != null ? $"{version.Major}.{version.Minor}" : "0.0";
     }
-    
-    private void PrintSauceJobLink(string testName)
+
+    private static async Task UpdateSauceResultAsync(IAPIRequestContext requestContext, string sessionId, bool passed)
     {
-        Console.WriteLine($"SauceOnDemandSessionID={_sessionId} job-name={testName}");
-        Console.WriteLine($"Test Job Link: https://app.saucelabs.com/tests/{_sessionId}");
-    }
-    
-    protected async Task AnnotateAsync(string comment)
-    {
-        if (_requestContext != null && !string.IsNullOrEmpty(_sessionId))
+        await requestContext.PutAsync($"{SauceApiUrl}/rest/v1/{SauceUsername}/jobs/{sessionId}", new APIRequestContextOptions
         {
-            var payload = new Dictionary<string, object>
+            Headers = new Dictionary<string, string>
             {
-                ["script"] = $"sauce:context={comment}",
-                ["args"] = Array.Empty<object>()
-            };
-            
-            await _requestContext.PostAsync($"session/{_sessionId}/execute/sync", new APIRequestContextOptions
-            {
-                DataObject = payload
-            });
-        }
+                ["Authorization"] = "Basic " + Convert.ToBase64String(Encoding.UTF8.GetBytes($"{SauceUsername}:{SauceAccessKey}"))
+            },
+            DataObject = new { passed }
+        });
+    }
+
+    private static void PrintSauceJobLink(string testName, string sessionId)
+    {
+        Console.WriteLine($"SauceOnDemandSessionID={sessionId} job-name={testName}");
+        Console.WriteLine($"Test Job Link: https://app.saucelabs.com/tests/{sessionId}");
     }
 
     protected async Task LoginAsync(string username = "standard_user", string password = "secret_sauce")
@@ -197,5 +290,31 @@ public abstract class TestBase
         await Page.Locator("[data-test='username']").FillAsync(username);
         await Page.Locator("[data-test='password']").FillAsync(password);
         await Page.Locator("[data-test='login-button']").ClickAsync();
+    }
+
+    // SessionId/RequestContext are null for a local session - there's no Sauce Labs job to report
+    // results to or link back to.
+    private sealed class WorkerSession(
+        IPlaywright playwright,
+        IBrowser browser,
+        string? sessionId = null,
+        IAPIRequestContext? requestContext = null)
+    {
+        public IPlaywright Playwright { get; } = playwright;
+        public IBrowser Browser { get; } = browser;
+        public string? SessionId { get; } = sessionId;
+        public IAPIRequestContext? RequestContext { get; } = requestContext;
+    }
+}
+
+// Runs once after every test in the assembly has finished, closing out whatever class sessions
+// (local or Sauce) are still open (see ClassSessions above).
+[SetUpFixture]
+public class SauceSessionsTeardown
+{
+    [OneTimeTearDown]
+    public async Task CloseAllSauceSessions()
+    {
+        await TestBase.CloseAllWorkerSessionsAsync();
     }
 }

--- a/PlaywrightExamples/TestBase.cs
+++ b/PlaywrightExamples/TestBase.cs
@@ -52,7 +52,12 @@ public abstract class TestBase
             ? SessionGrouping.Test
             : SessionGrouping.Class;
 
-    private static readonly string BrowserName = Environment.GetEnvironmentVariable("BROWSER") ?? "chromium";
+    // Normalized once here (not just inside GetBrowserType) because the raw value is also sent
+    // verbatim to Sauce in BuildCapabilitiesPayload and appended to the native WebSocket URL -
+    // either would reject a mixed-case or whitespace-padded value even though GetBrowserType itself
+    // tolerates it.
+    private static readonly string BrowserName =
+        (Environment.GetEnvironmentVariable("BROWSER") ?? "chromium").Trim().ToLowerInvariant();
 
     private static readonly string SauceUsername = Environment.GetEnvironmentVariable("SAUCE_USERNAME") ?? "";
     private static readonly string SauceAccessKey = Environment.GetEnvironmentVariable("SAUCE_ACCESS_KEY") ?? "";
@@ -137,8 +142,13 @@ public abstract class TestBase
 
         while (response.Status == 303)
         {
-            var location = response.Headers["location"];
-            response = await requestContext.GetAsync(location, new APIRequestContextOptions { MaxRedirects = 0 });
+            if (!response.Headers.TryGetValue("location", out var location))
+            {
+                throw new InvalidOperationException(
+                    $"Sauce responded {response.Status} to POST playwright/session without a Location header.");
+            }
+
+            response = await requestContext.GetAsync(location, new APIRequestContextOptions { MaxRedirects = 0, Timeout = 120000 });
         }
 
         var responseText = await response.TextAsync();
@@ -234,7 +244,7 @@ public abstract class TestBase
 
     // Closes every session still in ClassSessions ("test" mode never populates it - each session
     // is already closed in BaseTearDown). Invoked once after all tests finish, by
-    // SauceSessionsTeardown's [OneTimeTearDown] below. Any class session that ever failed a test
+    // SessionsTeardown's [OneTimeTearDown] below. Any class session that ever failed a test
     // was already evicted and closed in BaseTearDown, so everything left here only ever ran
     // passing tests - each is reported as passed.
     internal static async Task CloseAllWorkerSessionsAsync()
@@ -262,8 +272,9 @@ public abstract class TestBase
     }
 
     // The session endpoint accepts 'chromium', 'firefox' or 'webkit' - the same names Playwright
-    // itself uses, so no translation table is needed.
-    private static IBrowserType GetBrowserType(IPlaywright playwright, string browserName) => browserName.ToLowerInvariant() switch
+    // itself uses, so no translation table is needed. browserName is expected pre-normalized (see
+    // BrowserName above).
+    private static IBrowserType GetBrowserType(IPlaywright playwright, string browserName) => browserName switch
     {
         "chromium" => playwright.Chromium,
         "firefox" => playwright.Firefox,
@@ -324,10 +335,10 @@ public abstract class TestBase
 // Runs once after every test in the assembly has finished, closing out whatever class sessions
 // (local or Sauce) are still open (see ClassSessions above).
 [SetUpFixture]
-public class SauceSessionsTeardown
+public class SessionsTeardown
 {
     [OneTimeTearDown]
-    public async Task CloseAllSauceSessions()
+    public async Task CloseAllSessions()
     {
         await TestBase.CloseAllWorkerSessionsAsync();
     }

--- a/PlaywrightExamples/TestBase.cs
+++ b/PlaywrightExamples/TestBase.cs
@@ -77,7 +77,7 @@ public abstract class TestBase
     {
         if (Grouping == SessionGrouping.Class)
         {
-            var className = TestContext.CurrentContext.Test.ClassName ?? "";
+            var className = ClassSessionKey();
             var lazySession = ClassSessions.GetOrAdd(className, _ =>
                 new Lazy<Task<WorkerSession>>(() => OpenSessionAsync(ShortClassName(className)),
                     LazyThreadSafetyMode.ExecutionAndPublication));
@@ -91,6 +91,15 @@ public abstract class TestBase
         _context = await _session.Browser.NewContextAsync();
         Page = await _context.NewPageAsync();
     }
+
+    // The same key must be used everywhere ClassSessions is read or written (BaseSetUp and the
+    // eviction path in BaseTearDown) - a mismatch would let two different fixtures collide on one
+    // entry, or let teardown fail to find the entry it just used. ClassName is only ever null for
+    // a test with no fixture, which GROUPING=class doesn't support - fail loudly rather than
+    // silently bucket such a test under a shared "" key.
+    private static string ClassSessionKey() =>
+        TestContext.CurrentContext.Test.ClassName
+        ?? throw new InvalidOperationException("GROUPING=class requires the test to belong to a fixture (ClassName was null).");
 
     private static string ShortClassName(string fullClassName) => fullClassName.Split('.')[^1];
 
@@ -157,7 +166,7 @@ public abstract class TestBase
 
             Console.WriteLine($"Test: {testName} - Result: {result}");
 
-            if (_session.SessionId != null)
+            if (_session != null && _session.SessionId != null)
             {
                 PrintSauceJobLink(testName, _session.SessionId);
             }
@@ -168,27 +177,32 @@ public abstract class TestBase
         }
         finally
         {
-            await Page.CloseAsync();
+            // Page/_session are only null if BaseSetUp threw before reaching that point - nothing
+            // to clean up in that case, and touching them here would throw a NullReferenceException
+            // that masks the real SetUp failure in the test result.
+            if (Page != null) await Page.CloseAsync();
             if (_context != null) await _context.CloseAsync();
 
-            if (Grouping == SessionGrouping.Class)
+            if (_session != null)
             {
-                // Passed: leave the session in ClassSessions for the next test in this class to
-                // reuse. Failed: evict and close it now instead of leaving a possibly-dirty
-                // browser for the next test in this class to inherit - safe to do unconditionally
-                // because ParallelScope.Fixtures guarantees no sibling test is using it right now.
-                if (!passed)
+                if (Grouping == SessionGrouping.Class)
                 {
-                    var className = TestContext.CurrentContext.Test.ClassName ?? "";
-                    ClassSessions.TryRemove(className, out _);
-                    await CloseSessionAsync(_session, passed: false);
+                    // Passed: leave the session in ClassSessions for the next test in this class to
+                    // reuse. Failed: evict and close it now instead of leaving a possibly-dirty
+                    // browser for the next test in this class to inherit - safe to do unconditionally
+                    // because ParallelScope.Fixtures guarantees no sibling test is using it right now.
+                    if (!passed)
+                    {
+                        ClassSessions.TryRemove(ClassSessionKey(), out _);
+                        await CloseSessionAsync(_session, passed: false);
+                    }
                 }
-            }
-            else
-            {
-                // "test" mode sessions are never shared, so there's nobody to hand this off to -
-                // always close and report, pass or fail.
-                await CloseSessionAsync(_session, passed);
+                else
+                {
+                    // "test" mode sessions are never shared, so there's nobody to hand this off to -
+                    // always close and report, pass or fail.
+                    await CloseSessionAsync(_session, passed);
+                }
             }
         }
     }

--- a/PlaywrightExamples/Tests/AuthenticationTests.cs
+++ b/PlaywrightExamples/Tests/AuthenticationTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace PlaywrightExamples.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.All)]
+[Parallelizable(ParallelScope.Fixtures)]
 public class AuthenticationTests : TestBase
 {
     [Test]

--- a/PlaywrightExamples/Tests/CartTests.cs
+++ b/PlaywrightExamples/Tests/CartTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace PlaywrightExamples.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.All)]
+[Parallelizable(ParallelScope.Fixtures)]
 public class CartTests : TestBase
 {
     [Test]

--- a/PlaywrightExamples/Tests/CheckoutTests.cs
+++ b/PlaywrightExamples/Tests/CheckoutTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace PlaywrightExamples.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.All)]
+[Parallelizable(ParallelScope.Fixtures)]
 public class CheckoutTests : TestBase
 {
     [Test]

--- a/PlaywrightExamples/Tests/NavigationTests.cs
+++ b/PlaywrightExamples/Tests/NavigationTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace PlaywrightExamples.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.All)]
+[Parallelizable(ParallelScope.Fixtures)]
 public class NavigationTests : TestBase
 {
     [Test]

--- a/PlaywrightExamples/Tests/SortingTests.cs
+++ b/PlaywrightExamples/Tests/SortingTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace PlaywrightExamples.Tests;
 
 [TestFixture]
-[Parallelizable(ParallelScope.All)]
+[Parallelizable(ParallelScope.Fixtures)]
 public class SortingTests : TestBase
 {
     [Test]


### PR DESCRIPTION
## Summary
- Replaces the CDP/Grid-only `TestBase.cs` setup with a `TARGET=local|sauce` switch (default `local`): tests run against a locally launched browser or Sauce Labs' native Playwright WebSocket endpoint with no behavioral differences beyond where the browser lives. `BROWSER` (`chromium`/`firefox`/`webkit`) selects the engine identically for both targets.
- Sessions are shared per test class by default (`GROUPING=class`) - one session per class, named after it, relying on `[Parallelizable(ParallelScope.Fixtures)]` so exactly one test at a time ever touches a given class's session. `GROUPING=test` opts into a dedicated, uniquely-named session per test instead. Either mode: a failing test closes its session immediately instead of handing a possibly-dirty browser to the next test; a passing test's session stays available for reuse.
- Fixes two bugs found while validating `TARGET=sauce` against real Sauce Labs:
  - `HttpCredentials.Send` now explicitly sends Basic Auth proactively (`Always`) - its default (`Unauthorized`) was silently sending every request unauthenticated.
  - The native session payload's `playwrightVersion` now reads `Assembly.GetName().Version` instead of the stale, unrelated `AssemblyInformationalVersionAttribute` value baked into `Microsoft.Playwright.dll`.
- README updated to document `TARGET`/`BROWSER`/`GROUPING`, local vs. Sauce setup, and the built-in `dotnet test --logger html` report option.

## Test plan
- [x] `dotnet build` - 0 warnings/errors
- [x] `dotnet test` (local, default `TARGET`) - all 23 tests pass
- [x] `BROWSER=firefox dotnet test` (local) - passes
- [x] `TARGET=sauce dotnet test --filter Name=SignInSuccessful` - passes against real Sauce Labs
- [x] `TARGET=sauce dotnet test --filter FullyQualifiedName~AuthenticationTests` - all 4 tests share one Sauce session (confirmed via Sauce Jobs REST API: `name: "AuthenticationTests"`, `passed: true`)
- [x] `TARGET=sauce dotnet test` (full suite) - 23/23 pass, exactly 5 distinct Sauce sessions (one per test class)
- [x] `TARGET=sauce GROUPING=test dotnet test --filter Name=SignInSuccessful` - session named after the individual test

🤖 Generated with [Claude Code](https://claude.com/claude-code)